### PR TITLE
Handle multiple lines at once in LogHandlers

### DIFF
--- a/src/lib/docker/images/create/docker_image_build_task.py
+++ b/src/lib/docker/images/create/docker_image_build_task.py
@@ -44,4 +44,4 @@ class DockerBuildImageTask(DockerImageCreatorBaseTask):
                 self.logger, "build image %s" % image_info.get_target_complete_name())
             for log_line in output_generator:
                 still_running_logger.log()
-                log_hanlder.handle_log_line(log_line)
+                log_hanlder.handle_log_lines(log_line)

--- a/src/lib/docker/images/create/docker_image_pull_task.py
+++ b/src/lib/docker/images/create/docker_image_pull_task.py
@@ -54,4 +54,4 @@ class DockerPullImageTask(DockerImageCreatorBaseTask):
                 self.logger, "pull image %s" % image_info.get_source_complete_name())
             for log_line in output_generator:
                 still_running_logger.log()
-                log_handler.handle_log_line(log_line)
+                log_handler.handle_log_lines(log_line)

--- a/src/lib/docker/images/create/utils/build_log_handler.py
+++ b/src/lib/docker/images/create/utils/build_log_handler.py
@@ -15,8 +15,6 @@ class BuildLogHandler(AbstractLogHandler):
         self._image_info = image_info
 
     def handle_log_line(self, log_line, error: bool = False):
-        log_line = log_line.decode("utf-8")
-        log_line = log_line.strip('\r\n')
         json_output = json.loads(log_line)
         if "stream" in json_output:
             self._complete_log.append(json_output["stream"])

--- a/src/lib/docker/images/create/utils/docker_registry_image_checker.py
+++ b/src/lib/docker/images/create/utils/docker_registry_image_checker.py
@@ -1,9 +1,29 @@
-import json
 import multiprocessing as mp
 from typing import Dict
 
 import docker
 
+import json
+
+from ......lib.config.log_config import WriteLogFilesToConsole
+from ......lib.docker.images.image_info import ImageInfo
+from ......lib.logging.abstract_log_handler import AbstractLogHandler
+
+
+class DockerRegistryImageCheckerPullLogHandler(AbstractLogHandler):
+
+    def __init__(self):
+        super().__init__(None,None)
+        self.result = False
+
+    def handle_log_line(self, log_line, error: bool = False):
+        json_output = json.loads(log_line)
+        print(json_output)
+        # TODO logging
+        if "status" in json_output and json_output["status"].startswith("Pulling"):
+            return True
+        elif "errorDetail" in json_output:
+            return False
 
 class DockerRegistryImageChecker:
     def map(self, image: str, queue: mp.Queue):
@@ -14,10 +34,7 @@ class DockerRegistryImageChecker:
                 stream=True,
             )
             for log_line in generator:
-                log_line = log_line.decode("utf-8")
-                log_line = log_line.strip('\r\n')
-                json_output = json.loads(log_line)
-                queue.put(json_output)
+                queue.put(log_line)
             queue.put(None)
         except Exception as e:
             queue.put(e)
@@ -25,6 +42,7 @@ class DockerRegistryImageChecker:
             client.close()
 
     def check(self, image: str):
+        log_handler = DockerRegistryImageCheckerPullLogHandler()
         queue = mp.Queue()
         process = mp.Process(target=self.map, args=(image, queue))
         process.start()
@@ -33,12 +51,8 @@ class DockerRegistryImageChecker:
                 value = queue.get()
                 if isinstance(value, Exception):
                     raise value
-                elif isinstance(value, Dict):
-                    if "status" in value and value["status"].startswith("Pulling"):
-                        return True
-                    elif "errorDetail" in value:
-                        # TODO logger debug
-                        return False
+                elif isinstance(value, bytes):
+                    return any(log_handler.handle_log_lines(value))
                 elif value is None:
                     return False
                 else:

--- a/src/lib/docker/images/create/utils/pull_log_handler.py
+++ b/src/lib/docker/images/create/utils/pull_log_handler.py
@@ -12,8 +12,6 @@ class PullLogHandler(AbstractLogHandler):
         self._image_info = image_info
 
     def handle_log_line(self, log_line, error: bool = False):
-        log_line = log_line.decode("utf-8")
-        log_line = log_line.strip('\r\n')
         json_output = json.loads(log_line)
         if "status" in json_output \
                 and json_output["status"] != "Downloading" \

--- a/src/lib/docker/images/push/docker_image_push_base_task.py
+++ b/src/lib/docker/images/push/docker_image_push_base_task.py
@@ -44,4 +44,4 @@ class DockerPushImageBaseTask(DockerBaseTask):
                 self.logger, "push image %s" % image_info.get_target_complete_name())
             for log_line in output_generator:
                 still_running_logger.log()
-                log_hanlder.handle_log_line(log_line)
+                log_hanlder.handle_log_lines(log_line)

--- a/src/lib/docker/images/push/push_log_handler.py
+++ b/src/lib/docker/images/push/push_log_handler.py
@@ -12,8 +12,6 @@ class PushLogHandler(AbstractLogHandler):
         self._image_info = image_info
 
     def handle_log_line(self, log_line, error: bool = False):
-        log_line = log_line.decode("utf-8")
-        log_line = log_line.strip('\r\n')
         json_output = json.loads(log_line)
         if "status" in json_output and json_output["status"] != "Pushing":
             self._complete_log.append(json_output["status"])

--- a/src/lib/logging/abstract_log_handler.py
+++ b/src/lib/logging/abstract_log_handler.py
@@ -11,15 +11,27 @@ class AbstractLogHandler:
         self._log_config = log_config()
 
     def __enter__(self):
-        self._log_file = self._log_file_path.open("w")
+        if self._log_file_path is not None:
+            self._log_file = self._log_file_path.open("w")
         return self
 
     def __exit__(self, type, value, traceback):
-        self._log_file.close()
+        if self._log_file_path is not None:
+            self._log_file.close()
         self.finish()
+
+    def handle_log_lines(self, log_lines, error: bool = False):
+        log_lines = log_lines.decode("utf-8")
+        log_lines = log_lines.strip('\r\n')
+        result = []
+        for log_line in log_lines.split("\n"):
+            log_line = log_line.strip('\r\n')
+            result.append(self.handle_log_line(log_line, error))
+        return result
 
     def handle_log_line(self, log_line, error: bool = False):
         pass
 
     def finish(self):
         pass
+

--- a/src/lib/logging/command_log_handler.py
+++ b/src/lib/logging/command_log_handler.py
@@ -11,7 +11,6 @@ class CommandLogHandler(AbstractLogHandler):
         self._description = description
 
     def handle_log_line(self, log_line, error: bool = False):
-        log_line = log_line.decode("utf-8")
         self._log_file.write(log_line)
         self._complete_log.append(log_line)
         if error:

--- a/src/lib/logging/container_log_handler.py
+++ b/src/lib/logging/container_log_handler.py
@@ -11,7 +11,6 @@ class ContainerLogHandler(AbstractLogHandler):
         self.db_container_name = description
 
     def handle_log_line(self, log_line, error: bool = False):
-        log_line = log_line.decode("utf-8")
         self._log_file.write(log_line)
         self._complete_log.append(log_line)
 

--- a/src/lib/test_environment/db_container_log_thread.py
+++ b/src/lib/test_environment/db_container_log_thread.py
@@ -35,7 +35,7 @@ class DBContainerLogThread(Thread):
                 log = self.container.logs(since=self.previous_timestamp, until=self.current_timestamp)
                 if len(log) != 0:
                     still_running_logger.log()
-                    log_handler.handle_log_line(log)
+                    log_handler.handle_log_lines(log)
                 log_line = log.decode("utf-8").lower()
                 if ("error" in log_line and not "sshd was not started") \
                         or "exception" in log_line \

--- a/src/lib/test_environment/spawn_test_database.py
+++ b/src/lib/test_environment/spawn_test_database.py
@@ -72,7 +72,7 @@ class SpawnTestDockerDatabase(DockerBaseTask, DockerDBTestEnvironmentParameter):
                 self.logger, "pull image %s" % image_info.get_source_complete_name())
             for log_line in output_generator:
                 still_running_logger.log()
-                log_hanlder.handle_log_line(log_line)
+                log_hanlder.handle_log_lines(log_line)
 
     def _create_database_container(self, db_ip_address: str, db_private_network: str):
         self.logger.info("Starting database container %s", self.db_container_name)


### PR DESCRIPTION
Docker on MacOSX seems to return multiple lines at once when streaming API call logs. This patch extends the API of all LogHandlers with the function handle_log_lines to accept multiple lines. The AbstractLogHandler does the decoding and splitting of the lines and feeds them into the method handle_log_line. 
The DockerRegistryImageChecker used before its own method to parse the log, it now uses a specific implementation of the LogHandler which simplifies this step.