### PR TITLE
Fix init script for calls from different directories

### DIFF
--- a/start-test-env
+++ b/start-test-env
@@ -8,7 +8,7 @@
 COMMAND_LINE_ARGS=$*
 SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
-source pipenv_utils.sh
+source "$SCRIPT_DIR/pipenv_utils.sh"
 
 run () {
     export PYTHONPATH="$SCRIPT_DIR"


### PR DESCRIPTION
Import pipenv_utils.sh via absolute path derived from script path