### PR TITLE
Add a simple GitHub action workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ "*" ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "*" ]
+    branches: [ "master" ]
 
 jobs:
   build:
@@ -22,4 +22,3 @@ jobs:
     
     - name: Start environment
       run: ./start-test-env spawn-test-environment --environment-name test --database-port-forward 8888 --bucketfs-port-forward 6666
-    

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18:04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
@@ -17,8 +17,3 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.6 # optional, default is 3.x
-    - name: Install pipenv
-      uses: dschep/install-pipenv-action@v1        
-    
-    - name: Start environment
-      run: ./start-test-env spawn-test-environment --environment-name test --database-port-forward 8888 --bucketfs-port-forward 6666

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,4 +24,4 @@ jobs:
     - name: Spawn environemnt
       run: ./start-test-env spawn-test-environment --environment-name test --database-port-forward 8888 --bucketfs-port-forward 6666
     - name: Test database
-      run: python3 -c "import pyexasol as p; C=p.connect(dsn='localhost:8888', user='sys', password='exasol'); s = C.execute("SELECT * FROM EXA_ALL_USERS"); print(s.fetchone())"
+      run: python3 -c "import pyexasol as p; C=p.connect(dsn='localhost:8888', user='sys', password='exasol'); s = C.execute('SELECT * FROM EXA_ALL_USERS'); print(s.fetchone())"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,4 +16,6 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6 # optional, default is 3.x
+        python-version: 3.6
+    - name: Install pipenv
+      uses: dschep/install-pipenv-action@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,3 +25,5 @@ jobs:
       run: ./start-test-env spawn-test-environment --environment-name test --database-port-forward 8888 --bucketfs-port-forward 6666
     - name: Test database
       run: python3 -c "import pyexasol as p; C=p.connect(dsn='localhost:8888', user='sys', password='exasol'); s = C.execute('SELECT * FROM EXA_ALL_USERS'); print(s.fetchone())"
+    - name: Test container
+      run: docker exec test_container_test ps -ef

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,13 +9,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
-      
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
         python-version: 3.6
     - name: Install pipenv
       uses: dschep/install-pipenv-action@v1
+    - name: Spawn environemnt
+      run: ./start-test-env spawn-test-environment --environment-name test --database-port-forward 8888 --bucketfs-port-forward 6666

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,5 +17,11 @@ jobs:
         python-version: 3.6
     - name: Install pipenv
       uses: dschep/install-pipenv-action@v1
+    - name: Pip Installer
+      uses: BSFishy/pip-action@v1
+      with:
+        packages: pyexasol
     - name: Spawn environemnt
       run: ./start-test-env spawn-test-environment --environment-name test --database-port-forward 8888 --bucketfs-port-forward 6666
+    - name: Test database
+      run: python3 -c "import pyexasol as p; C=p.connect(dsn='localhost:8888', user='sys', password='exasol'); s = C.execute("SELECT * FROM EXA_ALL_USERS"); print(s.fetchone())"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [ "*" ]
+  pull_request:
+    branches: [ "*" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-18:04
+
+    steps:
+    - uses: actions/checkout@v2
+      
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6 # optional, default is 3.x
+    - name: Install pipenv
+      uses: dschep/install-pipenv-action@v1        
+    
+    - name: Start environment
+      run: ./start-test-env spawn-test-environment --environment-name test --database-port-forward 8888 --bucketfs-port-forward 6666
+    


### PR DESCRIPTION
This simple GitHub action workflow is intended to test if it is possible to run the test environment on Github Actions. As it looks like, the test environment runs without any changes in Github Actions. It also can run with privileged mode and without direct_io=false which means the docker-db can use all its capabilities.