### PR TITLE
Improve log output

### DIFF
--- a/src/cli/common.py
+++ b/src/cli/common.py
@@ -112,7 +112,14 @@ def handle_failure(task: DependencyLoggerBaseTask, task_dependencies_dot_file: s
     generate_graph_from_task_dependencies(task, task_dependencies_dot_file)
     timedelta = datetime.now() - start_time
     print("The command failed after %s s with:" % timedelta.total_seconds())
+    print_task_failures(task)
 
+def print_task_failures(task: DependencyLoggerBaseTask):
+    print()
+    print("Task Failures:")
+    for failure in task.collect_failures():
+        print(failure)
+    print()
 
 def handle_success(task: DependencyLoggerBaseTask, task_dependencies_dot_file: str, start_time: datetime):
     generate_graph_from_task_dependencies(task, task_dependencies_dot_file)

--- a/src/lib/base/base_task.py
+++ b/src/lib/base/base_task.py
@@ -306,6 +306,17 @@ class BaseTask(Task):
         params.update(kwargs)
         return task_class(**params)
 
+    def cleanup(self):
+        self.logger.debug("Cleaning up")
+        if self._task_state != TaskState.CLEANUP and self._task_state != TaskState.CLEANED:
+            self._task_state = TaskState.CLEANUP
+            self.cleanup_child_task()
+            self.cleanup_task()
+            if self._get_tmp_path_for_task().exists():
+                shutil.rmtree(self._get_tmp_path_for_task())
+            self._task_state = TaskState.CLEANED
+        self.logger.debug("Cleanup finished")
+
     def cleanup_child_task(self):
         if self._run_dependencies_target.exists():
             _run_dependencies_tasks_from_target = self._run_dependencies_target.read()
@@ -325,13 +336,3 @@ class BaseTask(Task):
     def cleanup_task(self):
         pass
 
-    def cleanup(self):
-        self.logger.info("Cleaning up")
-        if self._task_state != TaskState.CLEANUP and self._task_state != TaskState.CLEANED:
-            self._task_state = TaskState.CLEANUP
-            self.cleanup_child_task()
-            self.cleanup_task()
-            if self._get_tmp_path_for_task().exists():
-                shutil.rmtree(self._get_tmp_path_for_task())
-            self._task_state = TaskState.CLEANED
-        self.logger.info("Cleanup finished")

--- a/src/lib/base/stoppable_base_task.py
+++ b/src/lib/base/stoppable_base_task.py
@@ -1,7 +1,8 @@
 from pathlib import Path
+from typing import List
 
 from .timeable_base_task import TimeableBaseTask
-
+import traceback
 
 class StoppingFurtherExecution(Exception):
     pass
@@ -11,23 +12,66 @@ class StoppableBaseTask(TimeableBaseTask):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.failed_target = Path(super()._get_output_path_for_job(), "TASKED_FAILED")
+        self.failed_target = Path(super()._get_output_path_for_job(), "TASK_FAILED")
+
+    def get_failure_log_path(self) -> Path:
+        path = Path(self.get_output_path(), "failure")
+        return path
 
     def run(self):
-        self.fail_if_any_task_failed()
-        task_generator = super().run()
-        if task_generator is not None:
-            yield from task_generator
+        try:
+            self.fail_if_any_task_failed()
+            task_generator = super().run()
+            if task_generator is not None:
+                yield from task_generator
+        except Exception as exception:
+            exception_tb = traceback.format_exc()
+            self.handle_failure(exception, exception_tb)
+            raise exception
 
     def fail_if_any_task_failed(self):
         if self.failed_target.exists():
             with self.failed_target.open("r") as f:
                 failed_task = f.read()
+            self.logger.error("Task %s failed. Stopping further execution." % failed_task)
             raise StoppingFurtherExecution("Task %s failed. Stopping further execution." % failed_task)
 
-    def on_failure(self, exception):
+    def handle_failure(self, exception, exception_tb):
         if not isinstance(exception, StoppingFurtherExecution):
+#            self.logger.error("Task %s failed. Got %s(%s).",self.task_id, type(exception), str(exception))
+            with self.get_failure_log_path().open("w") as f:
+                f.write("%s"%exception_tb)
             if not self.failed_target.exists():
                 with self.failed_target.open("w") as f:
                     f.write("%s" % self.task_id)
-        super().on_failure(exception)
+
+    def collect_failures(self):
+        failures = []
+        failures.extend(self.collect_failures_of_child_tasks())
+        if self.get_failure_log_path().exists(): 
+            with self.get_failure_log_path().open("r") as f:
+                exception = f.read()
+                prefix = '    '
+                formated_exception = prefix+prefix.join(exception.splitlines(True))
+                failures.append("- %s:\n%s" % (self.task_id, formated_exception))
+        return failures
+
+    def collect_failures_of_child_tasks(self)->List[str]:
+        failures_of_child_tasks = []
+        if self._run_dependencies_target.exists():
+            _run_dependencies_tasks_from_target = self._run_dependencies_target.read()
+        else:
+            _run_dependencies_tasks_from_target = []
+        _run_dependencies_tasks = self._run_dependencies_tasks + _run_dependencies_tasks_from_target
+        reversed_run_dependencies_task_list = list(_run_dependencies_tasks)
+        reversed_run_dependencies_task_list.reverse()
+        for task in reversed_run_dependencies_task_list:
+            if isinstance(task, StoppableBaseTask):
+                failures_of_child_tasks.extend(task.collect_failures())
+
+        reversed_registered_task_list = list(self._registered_tasks)
+        reversed_registered_task_list.reverse()
+        for task in reversed_registered_task_list:
+            if isinstance(task, StoppableBaseTask):
+                failures_of_child_tasks.extend(task.collect_failures())
+        return failures_of_child_tasks

--- a/src/test/test_base_task.py
+++ b/src/test/test_base_task.py
@@ -118,6 +118,22 @@ class TestTask10(TestBaseTask):
         time.sleep(1)
         print(self.parameter_1)
 
+class TestTask11(TestBaseTask):
+
+    def register_required(self):
+        task12_1 = self.create_child_task_with_common_params(TestTask12,p="1")
+        task12_2 = self.create_child_task_with_common_params(TestTask12,p="2")
+        self.task12_1_future = self.register_dependency(task12_1)
+        self.task12_2_future = self.register_dependency(task12_2)
+
+    def run_task(self):
+        pass
+
+class TestTask12(TestBaseTask):
+    p = Parameter()
+
+    def run_task(self):
+        raise Exception("%s"%self.task_id)
 
 class BaseTaskTest(unittest.TestCase):
 
@@ -158,6 +174,25 @@ class BaseTaskTest(unittest.TestCase):
             print(e)
         if task._get_tmp_path_for_job().exists():
             shutil.rmtree(str(task._get_tmp_path_for_job()))
+
+    def test_collect_failures(self):
+        self.set_job_id(TestTask11)
+        task = TestTask11()
+        try:
+            luigi.build([task], workers=3, local_scheduler=True, log_level="INFO")
+            failures = task.collect_failures()
+            print()
+            for failure in failures:
+                print(failure)
+                print()
+            print()
+            self.assertEquals(len(failures),2)
+        except Exception as e:
+            print(e)
+        if task._get_tmp_path_for_job().exists():
+            shutil.rmtree(str(task._get_tmp_path_for_job()))
+
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Remove cleanup logging
- Collect all task failures and print them at the end of the log