### PR TITLE
Fix exception if goals are not available for docker builds

### DIFF
--- a/.github/workflows/check_setup_py.yaml
+++ b/.github/workflows/check_setup_py.yaml
@@ -16,6 +16,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - uses: abatilo/actions-poetry@v2.0.0
+        poetry-version: 1.1.6
     - name: Run packaging update
       run: bash githooks/update_packaging.sh
     - name: Show changes on working copy

--- a/.github/workflows/check_setup_py.yaml
+++ b/.github/workflows/check_setup_py.yaml
@@ -16,6 +16,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - uses: abatilo/actions-poetry@v2.0.0
+      with:
         poetry-version: 1.1.6
     - name: Run packaging update
       run: bash githooks/update_packaging.sh

--- a/.github/workflows/check_setup_py.yaml
+++ b/.github/workflows/check_setup_py.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Show changes on working copy
       run: git status --porcelain=v1 -uno
     - name: Show diff on working copy
-      run: git diff
+      run: git diff --cached
     - name: Check if something changed after running the update script
       run: |
         [ -z "$(git status --porcelain=v1 -uno 2>/dev/null)" ] 

--- a/exasol_integration_test_docker_environment/lib/docker/images/clean/clean_images.py
+++ b/exasol_integration_test_docker_environment/lib/docker/images/clean/clean_images.py
@@ -1,0 +1,57 @@
+import luigi
+from exasol_integration_test_docker_environment.lib.base.docker_base_task import DockerBaseTask
+from exasol_integration_test_docker_environment.lib.config.docker_config import target_docker_repository_config
+from exasol_integration_test_docker_environment.lib.docker.images.utils import find_images_by_tag
+
+
+class CleanImageTask(DockerBaseTask):
+    image_id = luigi.Parameter()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def run_task(self):
+        self.logger.info("Try to remove dependent images of %s" % self.image_id)
+        yield from self.run_dependencies(self.get_clean_image_tasks_for_dependent_images())
+        for i in range(3):
+            try:
+                self.logger.info("Try to remove image %s" % self.image_id)
+                self._client.images.remove(image=self.image_id, force=True)
+                self.logger.info("Removed image %s" % self.image_id)
+                break
+            except Exception as e:
+                self.logger.info("Could not removed image %s got exception %s" % (self.image_id, e))
+
+    def get_clean_image_tasks_for_dependent_images(self):
+        image_ids = [str(possible_child).replace("sha256:", "") for possible_child
+                     in self._low_level_client.images(all=True, quiet=True)
+                     if self.is_child_image(possible_child)]
+        return [self.create_child_task(CleanImageTask, image_id=image_id)
+                for image_id in image_ids]
+
+    def is_child_image(self, possible_child):
+        try:
+            inspect = self._low_level_client.inspect_image(image=str(possible_child).replace("sha256:", ""))
+            return str(inspect["Parent"]).replace("sha256:", "") == self.image_id
+        except:
+            return False
+
+
+class CleanImagesStartingWith(DockerBaseTask):
+    starts_with_pattern = luigi.Parameter()
+
+    def register_required(self):
+        image_ids = [str(image.id).replace("sha256:", "")
+                     for image in self.find_images_to_clean()]
+        self.register_dependencies([self.create_child_task(CleanImageTask, image_id=image_id)
+                                    for image_id in image_ids])
+
+    def find_images_to_clean(self):
+        self.logger.info("Going to remove all images starting with %s" % self.starts_with_pattern)
+        filter_images = find_images_by_tag(self._client, lambda tag: tag.startswith(self.starts_with_pattern))
+        for i in filter_images:
+            self.logger.info("Going to remove following image: %s" % i.tags)
+        return filter_images
+
+    def run_task(self):
+        pass

--- a/exasol_integration_test_docker_environment/lib/docker/images/clean/clean_images.py
+++ b/exasol_integration_test_docker_environment/lib/docker/images/clean/clean_images.py
@@ -5,6 +5,7 @@ from exasol_integration_test_docker_environment.lib.docker.images.utils import f
 
 
 class CleanImageTask(DockerBaseTask):
+    jobid = luigi.Parameter("")
     image_id = luigi.Parameter()
 
     def __init__(self, *args, **kwargs):
@@ -38,6 +39,8 @@ class CleanImageTask(DockerBaseTask):
 
 
 class CleanImagesStartingWith(DockerBaseTask):
+
+    jobid = luigi.Parameter("")
     starts_with_pattern = luigi.Parameter()
 
     def register_required(self):

--- a/exasol_integration_test_docker_environment/lib/docker/images/create/docker_build_base.py
+++ b/exasol_integration_test_docker_environment/lib/docker/images/create/docker_build_base.py
@@ -33,7 +33,7 @@ class DockerBuildBase(DependencyLoggerBaseTask):
         self.analyze_tasks_futures = self.register_dependencies(self.create_analyze_tasks())
 
     def create_analyze_tasks(self) -> Dict[str, DockerAnalyzeImageTask]:
-        goals = self.get_goals()
+        goals = set(self.get_goals())
         self.goal_class_map = self.get_goal_class_map()
         self.available_goals = set(self.goal_class_map.keys())
         self._check_if_build_steps_to_rebuild_are_valid_goals()

--- a/exasol_integration_test_docker_environment/lib/docker/images/utils.py
+++ b/exasol_integration_test_docker_environment/lib/docker/images/utils.py
@@ -1,0 +1,9 @@
+from typing import Callable, List
+
+
+def find_images_by_tag(client, condition: Callable[[str], bool]) -> List:
+    images = client.images.list()
+    filter_images = [image for image in images
+                     if image.tags is not None and len(image.tags) > 0 and
+                     any([condition(tag) for tag in image.tags])]
+    return filter_images

--- a/exasol_integration_test_docker_environment/test/resources/test_docker_build_base/test_analyze_image/Dockerfile
+++ b/exasol_integration_test_docker_environment/test/resources/test_docker_build_base/test_analyze_image/Dockerfile
@@ -1,0 +1,1 @@
+FROM ubuntu:18.04

--- a/exasol_integration_test_docker_environment/test/test_docker_build_base.py
+++ b/exasol_integration_test_docker_environment/test/test_docker_build_base.py
@@ -1,0 +1,122 @@
+import shutil
+import time
+import unittest
+from pathlib import Path
+from datetime import datetime
+
+import docker
+import luigi
+from luigi import Parameter, Config
+
+from exasol_integration_test_docker_environment.lib.base.dependency_logger_base_task import DependencyLoggerBaseTask
+from exasol_integration_test_docker_environment.lib.base.json_pickle_parameter import JsonPickleParameter
+
+from typing import Set, Dict
+
+from exasol_integration_test_docker_environment.lib.config.docker_config import target_docker_repository_config, \
+    source_docker_repository_config
+from exasol_integration_test_docker_environment.lib.docker.images.create.docker_build_base import DockerBuildBase
+from exasol_integration_test_docker_environment.lib.docker.images.create.docker_image_analyze_task import \
+    DockerAnalyzeImageTask
+from exasol_integration_test_docker_environment.lib.docker.images.push.docker_push_parameter import DockerPushParameter
+from exasol_integration_test_docker_environment.lib.docker.images.push.push_task_creator_for_build_tasks import \
+    PushTaskCreatorFromBuildTasks
+from exasol_integration_test_docker_environment.lib.docker.images.clean.clean_images import CleanImagesStartingWith
+
+class TestDockerBuildBaseTestAnalyzeImage(DockerAnalyzeImageTask):
+
+    task_name = Parameter()
+
+    def get_target_repository_name(self) -> str:
+        return f"""exasol-test-docker-build-base"""
+
+    def get_source_repository_name(self) -> str:
+        return f"""exasol-test-docker-build-base"""
+
+    def get_source_image_tag(self):
+        return self.task_name
+
+    def get_target_image_tag(self):
+        return self.task_name
+
+    def get_mapping_of_build_files_and_directories(self):
+        return {}
+
+    def get_dockerfile(self):
+        script_dir = Path(__file__).resolve().parent
+        dockerfile_path = Path(script_dir, "resources/test_docker_build_base/test_analyze_image/Dockerfile")
+        return dockerfile_path
+
+    def is_rebuild_requested(self) -> bool:
+        return False
+
+
+class TestDockerBuildBase(DockerBuildBase):
+    goals = luigi.ListParameter([])
+
+    def get_goal_class_map(self) -> Dict[str, DockerAnalyzeImageTask]:
+        goal_class_map = {
+                "test-analyze-image-1": TestDockerBuildBaseTestAnalyzeImage(task_name="test-analyze-image-1"),
+                "test-analyze-image-2": TestDockerBuildBaseTestAnalyzeImage(task_name="test-analyze-image-2")
+                }
+        return goal_class_map
+
+    def get_default_goals(self) -> Set[str]:
+        goals = {"test-analyze-image-1"}
+        return goals
+
+    def get_goals(self):
+        return self.goals
+
+    def run_task(self):
+        build_tasks = self.create_build_tasks(False)
+        image_infos_futures = yield from self.run_dependencies(build_tasks)
+        image_infos = self.get_values_from_futures(image_infos_futures)
+        self.return_object(image_infos)
+
+class DockerBuildBaseTest(unittest.TestCase):
+
+    def set_job_id(self, task_cls):
+        strftime = datetime.now().strftime('%Y_%m_%d_%H_%M_%S')
+        job_id = f"{strftime}_{task_cls.__name__}"
+        config = luigi.configuration.get_config()
+        config.set('job_config', 'job_id', job_id)
+
+    def clean(self):
+        self.set_job_id(CleanImagesStartingWith)
+        task = CleanImagesStartingWith(starts_with_pattern="exasol-test-docker-build-base")
+        luigi.build([task], workers=1, local_scheduler=True, log_level="ERROR")
+        if task._get_tmp_path_for_job().exists():
+            shutil.rmtree(str(task._get_tmp_path_for_job()))
+
+    def setUp(self):
+        self.client = docker.from_env()
+        self.clean()
+
+    def tearDown(self):
+        self.clean()
+        self.client.close()
+
+    def test_default_parameter(self):
+        self.set_job_id(TestDockerBuildBase)
+        task = TestDockerBuildBase()
+        luigi.build([task], workers=1, local_scheduler=True, log_level="INFO")
+        if task._get_tmp_path_for_job().exists():
+            shutil.rmtree(str(task._get_tmp_path_for_job()))
+
+    def test_valid_non_default_goal(self):
+        self.set_job_id(TestDockerBuildBase)
+        task = TestDockerBuildBase(goals=["test-analyze-image-2"])
+        luigi.build([task], workers=1, local_scheduler=True, log_level="INFO")
+        if task._get_tmp_path_for_job().exists():
+            shutil.rmtree(str(task._get_tmp_path_for_job()))
+
+    def test_non_valid_non_default_goal(self):
+        self.set_job_id(TestDockerBuildBase)
+        with self.assertRaises(Exception) as contex:
+            task = TestDockerBuildBase(goals=["test-analyze-image-3"])
+        self.assertIn("Unknown goal(s)",str(contex.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ homepage = "https://github.com/exasol/integration-test-docker-environment"
 
 keywords = ['exasol', 'docker', 'testing']
 include = ["docker_db_config","ext"]
+exclude = ["exasol_integration_test_docker_environment/test"]
 
 [tool.poetry.dependencies]
 python = ">=3.6"

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ packages = \
  'exasol_integration_test_docker_environment.lib.data',
  'exasol_integration_test_docker_environment.lib.docker',
  'exasol_integration_test_docker_environment.lib.docker.images',
+ 'exasol_integration_test_docker_environment.lib.docker.images.clean',
  'exasol_integration_test_docker_environment.lib.docker.images.create',
  'exasol_integration_test_docker_environment.lib.docker.images.create.utils',
  'exasol_integration_test_docker_environment.lib.docker.images.push',
@@ -61,7 +62,8 @@ package_data = \
                                                 'docker_db_config/7.0.5/*',
                                                 'docker_db_config/7.0.6/*',
                                                 'docker_db_config/7.0.7/*',
-                                                'docker_db_config/7.0.8/*']}
+                                                'docker_db_config/7.0.8/*'],
+ 'exasol_integration_test_docker_environment.test': ['resources/test_docker_build_base/test_analyze_image/*']}
 
 install_requires = \
 ['click>=7.0',

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,7 @@ packages = \
  'exasol_integration_test_docker_environment.lib.test_environment',
  'exasol_integration_test_docker_environment.lib.test_environment.database_setup',
  'exasol_integration_test_docker_environment.lib.test_environment.database_waiters',
- 'exasol_integration_test_docker_environment.lib.test_environment.parameter',
- 'exasol_integration_test_docker_environment.test']
+ 'exasol_integration_test_docker_environment.lib.test_environment.parameter']
 
 package_data = \
 {'': ['*'],
@@ -62,8 +61,7 @@ package_data = \
                                                 'docker_db_config/7.0.5/*',
                                                 'docker_db_config/7.0.6/*',
                                                 'docker_db_config/7.0.7/*',
-                                                'docker_db_config/7.0.8/*'],
- 'exasol_integration_test_docker_environment.test': ['resources/test_docker_build_base/test_analyze_image/*']}
+                                                'docker_db_config/7.0.8/*']}
 
 install_requires = \
 ['click>=7.0',


### PR DESCRIPTION
- Add clean_images.py from exaslct to easily remove images during tests
-  Add jobid parameter to clean image tasks, such that we can run them multiple time with same input in one pyton interpreter
- Fix in docker_build_base.py for unknown goals
- Exclude tests from packaging in pyproject.toml
- Pin poetry to version 1.1.6 in check_setup_py.yaml
- Improve output of check_setup_py.yaml in case of a mismatch

Fixes #71 