### PR TITLE
Bug/#99 parameters for db tests are not optional

### DIFF
--- a/doc/changes/changes_0.4.0.md
+++ b/doc/changes/changes_0.4.0.md
@@ -19,12 +19,13 @@ If you need further versions, please open an issue.
 - [NVIDIA Container Runtime](https://github.com/NVIDIA/nvidia-container-runtime) for GPU accelerated UDFs
 
 ## Bug Fixes:
-n/a
+   - #99: Fixed click parameters for external-exasol-db-port and external-exasol-bucketfs-port
 
 ## Features / Enhancements:
     
    - #93: Add docker-db versions 7.0.11 and prepare release
    - #95: Changed changelog file names (#96)
+
 ## Refactoring:
 n/a  
 

--- a/exasol_integration_test_docker_environment/cli/options/test_environment_options.py
+++ b/exasol_integration_test_docker_environment/cli/options/test_environment_options.py
@@ -22,9 +22,9 @@ docker_db_options = [
 external_db_options = [
     click.option('--external-exasol-db-host', type=str,
                  help="""Host name or IP of external Exasol DB, needs to be set if --environment-type=external_db"""),
-    click.option('--external-exasol-db-port', type=str,
+    click.option('--external-exasol-db-port', type=int, default=8563,
                  help="""Database port of external Exasol DB, needs to be set if --environment-type=external_db"""),
-    click.option('--external-exasol-bucketfs-port', type=str,
+    click.option('--external-exasol-bucketfs-port', type=int, default=6583,
                  help="""Bucketfs port of external Exasol DB, needs to be set if --environment-type=external_db"""),
     click.option('--external-exasol-db-user', type=str,
                  help="""User for external Exasol DB, needs to be set if --environment-type=external_db"""),


### PR DESCRIPTION
Use int type with default value in click options for external-exasol-db-port and external-exasol-bucketfs-port
