### PR TITLE
Add support for using main over master as default branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
 

--- a/.github/workflows/publish_docker_runner.yml
+++ b/.github/workflows/publish_docker_runner.yml
@@ -3,7 +3,7 @@ name: Publish Docker Runner
 on:
   push:
     branches:
-      - master
+      - main
       - 'ci-release-test/**'
 
 jobs:
@@ -15,14 +15,14 @@ jobs:
     - name: Build new Docker image
       run: bash ./starter_scripts/build_docker_runner_image.sh
     - name: Docker login
-      run: echo "$SECRET_DOCKER_TOKEN" | docker login --username "$SECRET_DOCKER_USER_NAME" --password-stdin 
+      run: echo "$SECRET_DOCKER_TOKEN" | docker login --username "$SECRET_DOCKER_USER_NAME" --password-stdin
       env: # Set the secret as an input
         SECRET_DOCKER_USER_NAME: ${{ secrets.DOCKER_USER_NAME }}
         SECRET_DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
     - name: Push new Docker image
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/main'
       run: bash ./starter_scripts/push_docker_runner_image.sh
     - name: Push new ci-release-test Docker image
-      if: github.ref != 'refs/heads/master'
+      if: github.ref != 'refs/heads/main'
       run: bash ./starter_scripts/push_docker_runner_image.sh "ci-release-test"
 

--- a/.github/workflows/test_db_versions_all_tests.yml
+++ b/.github/workflows/test_db_versions_all_tests.yml
@@ -3,7 +3,7 @@ name: Test DB Versions with all tests
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/test_db_versions_minimal.yml
+++ b/.github/workflows/test_db_versions_minimal.yml
@@ -3,7 +3,7 @@ name: Test DB Versions with minimal tests
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 

--- a/.github/workflows/test_docker_starter.yml
+++ b/.github/workflows/test_docker_starter.yml
@@ -3,7 +3,7 @@ name: Test Docker Starter
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:
@@ -12,5 +12,5 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Test ./start-test-env 
+    - name: Test ./start-test-env
       run: ./start-test-env --help

--- a/.github/workflows/test_python_version.yml
+++ b/.github/workflows/test_python_version.yml
@@ -3,7 +3,7 @@ name: Test Python Versions with all tests
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -6,6 +6,6 @@ set -o pipefail
 REPO_DIR=$(git rev-parse --show-toplevel)
 GITHOOKS_PATH="$REPO_DIR/githooks"
 pushd "$REPO_DIR"
-bash "$GITHOOKS_PATH/prohibit_commit_to_master.sh"
+bash "$GITHOOKS_PATH/prohibit_commit_to_main.sh"
 bash "$GITHOOKS_PATH/update_packaging.sh"
 popd

--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -1,5 +1,5 @@
 #!/bin/bash
-protected_branches=( master )
+protected_branches=( main )
 for i in "${protected_branches[@]}"
 do
 

--- a/githooks/prohibit_commit_to_main.sh
+++ b/githooks/prohibit_commit_to_main.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+if [ "$branch" = "main" ]; then
+  echo "You can't commit directly to main branch"
+  exit 1
+fi

--- a/githooks/prohibit_commit_to_master.sh
+++ b/githooks/prohibit_commit_to_master.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-branch="$(git rev-parse --abbrev-ref HEAD)"
-
-if [ "$branch" = "master" ]; then
-  echo "You can't commit directly to master branch"
-  exit 1
-fi


### PR DESCRIPTION
Details about this renaming in generall can be found at https://github.com/github/renaming.

Once this branch is published and verified, a repository administrator
can switch to this branch as the default.

More about switching the default branch can be found at github.
* https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch

Related issue #136
