### PR TITLE
#169: Changed start-test-env script so that it switches to itde directory during execution

### DIFF
--- a/doc/changes/changes_0.11.0.md
+++ b/doc/changes/changes_0.11.0.md
@@ -20,7 +20,7 @@ If you need further versions, please open an issue.
 
 ## Bug Fixes:
 
-n/a
+ - #169: Changed start-test-env script so that it switches to itde directory during execution 
 
 ## Features / Enhancements:
 

--- a/start-test-env
+++ b/start-test-env
@@ -21,4 +21,6 @@ SCRIPT_DIR="$(dirname "$($rl -f "${BASH_SOURCE[0]}")")"
 bash "$SCRIPT_DIR/scripts/health.sh" "run"
 
 RUNNER_IMAGE_NAME="$("$SCRIPT_DIR/starter_scripts/construct_docker_runner_image_name.sh")"
+
+pushd $SCRIPT_DIR > /dev/null
 bash "$SCRIPT_DIR/starter_scripts/exaitde_within_docker_container_with_container_build.sh" "$RUNNER_IMAGE_NAME" "${@}"

--- a/start-test-env
+++ b/start-test-env
@@ -22,5 +22,5 @@ bash "$SCRIPT_DIR/scripts/health.sh" "run"
 
 RUNNER_IMAGE_NAME="$("$SCRIPT_DIR/starter_scripts/construct_docker_runner_image_name.sh")"
 
-pushd $SCRIPT_DIR > /dev/null
+pushd "$SCRIPT_DIR" > /dev/null
 bash "$SCRIPT_DIR/starter_scripts/exaitde_within_docker_container_with_container_build.sh" "$RUNNER_IMAGE_NAME" "${@}"


### PR DESCRIPTION
Fixes #169 

### All Submissions:

* [x] Is the title of the Pull Request correct?
* [x] Is the title of the corresponding issue correct?
* [x] Have you updated the changelog?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../../pulls) for the same update/change? <!-- markdown-link-check-disable-line --> 
* [x] Are you mentioning the issue which this PullRequest fixes ("Fixes...")
* [x] Before you merge don't forget to run all tests for all Exasol version, by adding `[run all tests]` to the commit message
