### PR TITLE
#230: Fixed default value of click option external-exasol-xmlrpc-port should be int

### DIFF
--- a/doc/changes/changes_0.12.0.md
+++ b/doc/changes/changes_0.12.0.md
@@ -19,6 +19,7 @@ TBD
 
 ## Bug Fixes:
 - #228: Fixed graph plot generator
+- #230: Fixed default value of click option external-exasol-xmlrpc-port should be int
 
 ## Features / Enhancements:
 

--- a/exasol_integration_test_docker_environment/cli/options/test_environment_options.py
+++ b/exasol_integration_test_docker_environment/cli/options/test_environment_options.py
@@ -39,7 +39,7 @@ external_db_options = [
     click.option('--external-exasol-xmlrpc-host', type=str,
                  help="""Hostname for the xmlrpc server"""),
     click.option('--external-exasol-xmlrpc-port', type=int,
-                 default="""443""", show_default=True,
+                 default=443, show_default=True,
                  help="""Port for the xmlrpc server"""),
     click.option('--external-exasol-xmlrpc-user', type=str,
                  default="""admin""", show_default=True,


### PR DESCRIPTION
fixes #230 

### All Submissions:

* [x] Is the title of the Pull Request correct?
* [x] Is the title of the corresponding issue correct?
* [x] Have you updated the changelog?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../../pulls) for the same update/change? <!-- markdown-link-check-disable-line --> 
* [x] Are you mentioning the issue which this PullRequest fixes ("Fixes...")
* [x] Before you merge don't forget to run all tests for all Exasol version, by adding `[run all tests]` to the commit message
