### PR TITLE
#244: Generate graph plot fails if task uses luigi.ListParameter

### DIFF
--- a/doc/changes/changes_0.12.0.md
+++ b/doc/changes/changes_0.12.0.md
@@ -21,6 +21,7 @@ TBD
 - #228: Fixed graph plot generator
 - #230: Fixed default value of click option external-exasol-xmlrpc-port should be int
 - #211: Fixed output of test DockerTestEnvironmentDockerRuntimeInvalidRuntimeGivenTest
+- #244: Fixed bug in generate graph plot if task uses luigi.ListParameter
 
 ## Features / Enhancements:
 

--- a/exasol_integration_test_docker_environment/lib/base/task_dependency.py
+++ b/exasol_integration_test_docker_environment/lib/base/task_dependency.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from sys import stderr
 
 import jsonpickle
 
@@ -11,8 +12,8 @@ class TaskDescription:
 
     @property
     def formatted_representation(self):
-        assert '"' not in self.representation
-        return f'"{self.representation}"'
+        representation = self.representation.replace('"', '\\"')
+        return f'"{representation}"'
 
     @property
     def formatted_id(self):

--- a/exasol_integration_test_docker_environment/test/test_generate_graph_plot.py
+++ b/exasol_integration_test_docker_environment/test/test_generate_graph_plot.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -9,20 +7,19 @@ import luigi
 from exasol_integration_test_docker_environment.cli.common import generate_root_task, run_task
 from exasol_integration_test_docker_environment.lib.base.dependency_logger_base_task import DependencyLoggerBaseTask
 
-from exasol_integration_test_docker_environment.lib.base.luigi_log_config import LOG_ENV_VARIABLE_NAME
-
 
 class TestTask(DependencyLoggerBaseTask):
     x = luigi.Parameter()
 
     def register_required(self):
-        self.register_dependency(self.create_child_task(task_class=TestChildTask))
+        self.register_dependency(self.create_child_task(task_class=TestChildTask, y=["1", "2", "3"]))
 
     def run(self):
         pass
 
 
 class TestChildTask(DependencyLoggerBaseTask):
+    y = luigi.ListParameter()
     def run_task(self):
         pass
 


### PR DESCRIPTION
fixes #244 

check https://github.com/exasol/integration-test-docker-environment/pull/229#discussion_r942988207 for problem


### All Submissions:

* [ ] Is the title of the Pull Request correct?
* [ ] Is the title of the corresponding issue correct?
* [ ] Have you updated the changelog?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../../pulls) for the same update/change? <!-- markdown-link-check-disable-line --> 
* [ ] Are you mentioning the issue which this PullRequest fixes ("Fixes...")
* [ ] Before you merge don't forget to run all tests for all Exasol version, by adding `[run all tests]` to the commit message
