### PR TITLE
Remove docker health checks from ITDE starter script

### DIFF
--- a/doc/changes/changelog.md
+++ b/doc/changes/changelog.md
@@ -1,5 +1,6 @@
 # Changes
 
+* [1.2.1](changes_1.2.1.md)
 * [1.2.0](changes_1.2.0.md)
 * [1.1.0](changes_1.1.0.md)
 * [1.0.0](changes_1.0.0.md)

--- a/doc/changes/changelog.md
+++ b/doc/changes/changelog.md
@@ -23,6 +23,7 @@
 ---
 hidden:
 ---
+changes_1.2.1
 changes_1.2.0
 changes_1.1.0
 changes_1.0.0

--- a/doc/changes/changes_1.2.1.md
+++ b/doc/changes/changes_1.2.1.md
@@ -1,0 +1,36 @@
+# Integration-Test-Docker-Environment 1.2.1, released \<TBD\>
+
+## Summary
+
+TBD
+
+### Supported Exasol Versions
+
+* **7.0**: up to 7.0.20, **except 7.0.5**
+* **7.1**: up to 7.1.15
+
+If you need further versions, please open an issue.
+
+### Tested Docker Runtimes
+
+- Docker Default Runtime
+
+## Bug Fixes:
+
+n/a
+
+## Features / Enhancements:
+
+n/a
+
+## Refactoring:
+
+- Removed docker health checks from ITDE starter script
+
+## Documentation:
+
+n/a
+
+## Security:
+
+n/a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "exasol-integration-test-docker-environment"
-version = "1.2.0"
+version = "1.2.1"
 description = "Integration Test Docker Environment for Exasol"
 
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ extras_require = \
 
 setup_kwargs = {
     'name': 'exasol-integration-test-docker-environment',
-    'version': '1.2.0',
+    'version': '1.2.1',
     'description': 'Integration Test Docker Environment for Exasol',
     'long_description': 'Integration Test Docker Environment\n===================================\n\nThis project provides a command line interface and a Python API layer to\nstart a test environment with an `Exasol\nDocker-DB <https://hub.docker.com/r/exasol/docker-db>`_. Both start an\nExasol Docker-DB container, but the API Layer has extended functionality\nand also can start an associated test container for whose content the\nclient is responsible.\n\nDocumentation\n-------------\n\n`Documentation for the current main branch <https://exasol.github.io/integration-test-docker-environment/main>`_ is hosted on the Github Pages of this project.\n`Here <https://exasol.github.io/integration-test-docker-environment>`_  is a list of documentations for previous releases.\n',
     'author': 'Torsten Kilias',

--- a/start-test-env
+++ b/start-test-env
@@ -18,8 +18,6 @@ fi
 
 SCRIPT_DIR="$(dirname "$($rl -f "${BASH_SOURCE[0]}")")"
 
-bash "$SCRIPT_DIR/scripts/health.sh" "run"
-
 RUNNER_IMAGE_NAME="$("$SCRIPT_DIR/starter_scripts/construct_docker_runner_image_name.sh")"
 
 pushd "$SCRIPT_DIR" > /dev/null


### PR DESCRIPTION
The connectivty test keeps yielding fals negativies, and therefore
is negatively impacting our CI/CD infrastructure. Thefore
the health checks have been disabled temporarily.
See also https://github.com/exasol/integration-test-docker-environment/issues/275

### All Submissions:

* [x] Is the title of the Pull Request correct?
* [x] Is the title of the corresponding issue correct?
* [x] Have you updated the changelog?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../../pulls) for the same update/change? <!-- markdown-link-check-disable-line --> 
* [x] Are you mentioning the issue which this PullRequest fixes ("Fixes...")
* [x] Before you merge don't forget to run all tests for all Exasol version, by adding `[run all tests]` to the commit message
