### PR TITLE
Add explicit dependency for docutils

### DIFF
--- a/doc/changes/changes_3.1.0.md
+++ b/doc/changes/changes_3.1.0.md
@@ -7,3 +7,4 @@ TBD
 ## Changes
 
 * Moved `pytest` dependency to development dependencies
+* Add explicit dependency and version constraint (`<= 0.20.1`) for `docutils`

--- a/poetry.lock
+++ b/poetry.lock
@@ -1992,4 +1992,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4"
-content-hash = "1c5147bf2d53f3196d63beafcc79d8e1d04a4de84126984d88ef2bba79a65b9d"
+content-hash = "39d8fc1e2b420b86bf2e27f07c175749604bcf28a6156a34ea86def940af97d2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,12 @@ exasol-bucketfs = ">=0.6.0,<2.0.0"
 fabric = "^3.0.1"
 portalocker = "^2.7.0"
 exasol-error-reporting = "^0.4.0"
+# The current combination of dependencies for ITDE and Luigi is not compatible with projects that run on Python 3.8.
+# The latest version of docutils, version 0.21.1, is required to run on Python 3.9 or higher. 
+# As a temporary fix, until support for Python 3.8 is dropped (which is estimated to be around 6 months),
+# we are explicitly requiring a version of docutils that is less than or equal to 0.20.1 in ITDE.
+# Once support for Python 3.8 is dropped, this dependency can be removed as it is only needed as a transitive dependency.
+docutils = "<=0.20.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.2"


### PR DESCRIPTION
 The current combination of dependencies for ITDE and Luigi is not compatible with projects that run on Python 3.8.
 The latest version of docutils, version 0.21.1, is required to run on Python 3.9 or higher. 
 As a temporary fix, until support for Python 3.8 is dropped (which is estimated to be around 6 months),
 we are explicitly requiring a version of docutils that is less than or equal to 0.20.1 in ITDE.
 Once support for Python 3.8 is dropped, this dependency can be removed as it is only needed as a transitive dependency.
