### PR TITLE
#417: Replaced Ubuntu 18.04 and Ubuntu 20.04 Docker images with Ubuntu 22.04

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -10,7 +10,7 @@ jobs:
 
   cd-job:
     name: Continuous Delivery
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
 
       - name: SCM Checkout

--- a/.github/workflows/check-release-tag.yml
+++ b/.github/workflows/check-release-tag.yml
@@ -7,7 +7,7 @@ jobs:
   check-tag-version-job:
 
     name: Check Tag Version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: SCM Checkout

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,7 +7,7 @@ jobs:
 
   Version-Check:
     name: Version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: SCM Checkout
@@ -25,7 +25,7 @@ jobs:
   Documentation:
     name: Docs
     needs: [ Version-Check ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: SCM Checkout
@@ -45,7 +45,7 @@ jobs:
   Lint:
     name: Linting (Python-${{ matrix.python-version }})
     needs: [ Version-Check, build-matrix ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.build-matrix.outputs.matrix) }}
@@ -72,7 +72,7 @@ jobs:
   Type-Check:
     name: Type Checking (Python-${{ matrix.python-version }})
     needs: [ Version-Check, build-matrix ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.build-matrix.outputs.matrix) }}
@@ -92,7 +92,7 @@ jobs:
   Security:
     name: Security Checks (Python-${{ matrix.python-version }})
     needs: [ Version-Check, build-matrix ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.build-matrix.outputs.matrix) }}
@@ -118,7 +118,7 @@ jobs:
 
   Format:
     name: Format Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: SCM Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
   slow-tests-approval:
     name: Approve Slow Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     # Even though the environment "manual-approval" will be created automatically,
     # it still needs to be configured to require interactive review.
@@ -45,7 +45,7 @@ jobs:
   # This job ensures inputs have been executed successfully.
   approve-merge:
     name: Allow Merge
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # If you need additional jobs to be part of the merge gate, add them below
     needs: [ checks, fast-tests, slow-tests ]
 

--- a/.github/workflows/fast-tests.yml
+++ b/.github/workflows/fast-tests.yml
@@ -14,7 +14,7 @@ jobs:
   fast-tests:
     name: Unit-Tests (Python-${{ matrix.python-version }}, Exasol-${{ matrix.exasol-version}})
     needs: [ build-matrix ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       GITHUB_TOKEN: ${{ secrets.ALTERNATIVE_GITHUB_TOKEN ||  secrets.GITHUB_TOKEN }}
     strategy:

--- a/.github/workflows/get-exasol-versions.yml
+++ b/.github/workflows/get-exasol-versions.yml
@@ -6,7 +6,7 @@ on:
         value: ${{ jobs.get_exasol_versions.outputs.matrix }}
 jobs:
   get_exasol_versions:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: SCM Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,7 +7,7 @@ on:
 jobs:
 
   documentation-job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: SCM Checkout

--- a/.github/workflows/matrix-python.yml
+++ b/.github/workflows/matrix-python.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   python_versions:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: SCM Checkout

--- a/.github/workflows/publish-docker-runner.yml
+++ b/.github/workflows/publish-docker-runner.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: publish
     steps:
 

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -6,7 +6,7 @@ on:
 jobs:
 
   report:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/test-db-versions-all-tests.yml
+++ b/.github/workflows/test-db-versions-all-tests.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         exasol_version: ${{fromJson(needs.get_exasol_versions.outputs.matrix)}}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Run all tests for Exasol ${{ matrix.exasol_version }}
 
     steps:

--- a/.github/workflows/test-db-versions-minimal.yml
+++ b/.github/workflows/test-db-versions-minimal.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         exasol_version: ${{fromJson(needs.get_exasol_versions.outputs.matrix)}}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: SCM Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-docker-starter.yml
+++ b/.github/workflows/test-docker-starter.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   test-docker-starter:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: SCM Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-python-versions.yml
+++ b/.github/workflows/test-python-versions.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.build-matrix.outputs.matrix) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: SCM Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-shell-scripts.yml
+++ b/.github/workflows/test-shell-scripts.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     name: Test Shell Scripts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: SCM Checkout
         uses: actions/checkout@v4

--- a/doc/changes/unreleased.md
+++ b/doc/changes/unreleased.md
@@ -1,1 +1,5 @@
 # Unreleased
+
+## Refactorings
+
+ - #417: Replaced Ubuntu 18.04 and Ubuntu 20.04 Docker images with Ubuntu 22.04

--- a/exasol_integration_test_docker_environment/certificate_resources/container/Dockerfile
+++ b/exasol_integration_test_docker_environment/certificate_resources/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 

--- a/exasol_integration_test_docker_environment/lib/base/base_task.py
+++ b/exasol_integration_test_docker_environment/lib/base/base_task.py
@@ -109,7 +109,7 @@ class RunTaskFuture(AbstractTaskFuture):
 
 
 class BaseTask(Task):
-    caller_output_path: List[str] = luigi.ListParameter([])  # type: ignore
+    caller_output_path: List[str] = luigi.ListParameter([], significant=False, visibility=ParameterVisibility.HIDDEN)  # type: ignore
     job_id: str = luigi.Parameter()  # type: ignore
 
     def __init__(self, *args, **kwargs):

--- a/exasol_integration_test_docker_environment/lib/base/base_task.py
+++ b/exasol_integration_test_docker_environment/lib/base/base_task.py
@@ -109,7 +109,7 @@ class RunTaskFuture(AbstractTaskFuture):
 
 
 class BaseTask(Task):
-    caller_output_path: List[str] = luigi.ListParameter([], significant=False, visibility=ParameterVisibility.HIDDEN)  # type: ignore
+    caller_output_path: List[str] = luigi.ListParameter([])  # type: ignore
     job_id: str = luigi.Parameter()  # type: ignore
 
     def __init__(self, *args, **kwargs):

--- a/exasol_integration_test_docker_environment/lib/test_environment/spawn_test_database.py
+++ b/exasol_integration_test_docker_environment/lib/test_environment/spawn_test_database.py
@@ -340,7 +340,7 @@ class SpawnTestDockerDatabase(DockerBaseTask, DockerDBTestEnvironmentParameter):
             self._remove_volume(volume_name)
         volume = docker_client.volumes.create(volume_name)
         container = docker_client.containers.run(
-            image="ubuntu:18.04",
+            image="ubuntu:22.04",
             name=container_name,
             auto_remove=True,
             command="sleep infinity",

--- a/exasol_integration_test_docker_environment/test/resources/test_container/full/Dockerfile
+++ b/exasol_integration_test_docker_environment/test/resources/test_container/full/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/exasol_integration_test_docker_environment/test/resources/test_container/mock/Dockerfile
+++ b/exasol_integration_test_docker_environment/test/resources/test_container/mock/Dockerfile
@@ -1,3 +1,3 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 COPY test.text /test.text

--- a/exasol_integration_test_docker_environment/test/resources/test_docker_build_base/test_analyze_image/Dockerfile
+++ b/exasol_integration_test_docker_environment/test/resources/test_docker_build_base/test_analyze_image/Dockerfile
@@ -1,1 +1,1 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04

--- a/exasol_integration_test_docker_environment/test/resources/test_test_container_reuse/tests/Dockerfile
+++ b/exasol_integration_test_docker_environment/test/resources/test_test_container_reuse/tests/Dockerfile
@@ -1,1 +1,1 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04

--- a/exasol_integration_test_docker_environment/test/test_api_test_environment_docker_runtime.py
+++ b/exasol_integration_test_docker_environment/test/test_api_test_environment_docker_runtime.py
@@ -26,7 +26,7 @@ def assert_container_runtime(self, container_name, expected_runtime):
 
 def get_default_docker_runtime():
     with ContextDockerClient() as docker_client:
-        tmp_container = docker_client.containers.create("ubuntu:18.04", "echo")
+        tmp_container = docker_client.containers.create("ubuntu:22.04", "echo")
         try:
             tmp_container.reload()
             default_docker_runtime = tmp_container.attrs["HostConfig"]["Runtime"]

--- a/exasol_integration_test_docker_environment/test/test_base_task.py
+++ b/exasol_integration_test_docker_environment/test/test_base_task.py
@@ -1,4 +1,5 @@
 import shutil
+import tempfile
 import time
 import unittest
 
@@ -195,6 +196,15 @@ class TestTask14(TestBaseTask):
 class TestTask15(TestBaseTask):
     def run_task(self):
         raise Exception("%s" % self.task_id)
+
+class TestTask16(TestBaseTask):
+    def run_task(self):
+        temp_directory = tempfile.mkdtemp(
+            prefix="release_archive_",
+        )
+        self.return_object(temp_directory)
+
+
 
 
 class BaseTaskTest(unittest.TestCase):

--- a/exasol_integration_test_docker_environment/test/test_base_task.py
+++ b/exasol_integration_test_docker_environment/test/test_base_task.py
@@ -1,5 +1,4 @@
 import shutil
-import tempfile
 import time
 import unittest
 
@@ -196,15 +195,6 @@ class TestTask14(TestBaseTask):
 class TestTask15(TestBaseTask):
     def run_task(self):
         raise Exception("%s" % self.task_id)
-
-class TestTask16(TestBaseTask):
-    def run_task(self):
-        temp_directory = tempfile.mkdtemp(
-            prefix="release_archive_",
-        )
-        self.return_object(temp_directory)
-
-
 
 
 class BaseTaskTest(unittest.TestCase):

--- a/scripts/health.sh
+++ b/scripts/health.sh
@@ -103,7 +103,7 @@ docker_check_version () {
 docker_check_pull () {
   local docker_cmd=$1
   local details
-  details=$("docker" pull ubuntu:18.04 2>&1)
+  details=$("docker" pull ubuntu:22.04 2>&1)
   # We want to store the details of the command, for error reporting. Therefore we won't check within the if.
   # shellcheck disable=SC2181
   if [ $? -ne 0 ]; then
@@ -117,7 +117,7 @@ docker_check_pull () {
 docker_check_connectivity () {
   local docker_cmd=$1
   local details
-  details=$(docker run --rm ubuntu:18.04 bash -c ": >/dev/tcp/1.1.1.1/53")
+  details=$(docker run --rm ubuntu:22.04 bash -c ": >/dev/tcp/1.1.1.1/53")
   # We want to store the details of the command, for error reporting. Therefore we won't check within the if.
   # shellcheck disable=SC2181
   if [ $? -ne 0 ]; then


### PR DESCRIPTION
fixes #417

### All Submissions:

* [x] Is the title of the Pull Request correct?
* [x] Is the title of the corresponding issue correct?
* [x] Have you updated the changelog?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../../pulls) for the same update/change? <!-- markdown-link-check-disable-line --> 
* [x] Are you mentioning the issue which this PullRequest fixes ("Fixes...")
* [x] Are the CLI usage examples up to date?





### Todo List


Update Ubuntu docker images (proposal: to 22.04). There are still some places using the 18.04 Ubuntu image, like:

- [x]  heath.sh 

    - [x]  docker_check_pull: https://github.com/exasol/integration-test-docker-environment/blob/a77a910447a9b3571f8effb0b8cfd9cf6677b81e/scripts/health.sh#L106
    -  [x]  docker_check_connectivity: https://github.com/exasol/integration-test-docker-environment/blob/a77a910447a9b3571f8effb0b8cfd9cf6677b81e/scripts/health.sh#L120 
 - [x]  [spawn_test_database.py](https://github.com/exasol/integration-test-docker-environment/blob/a77a910447a9b3571f8effb0b8cfd9cf6677b81e/exasol_integration_test_docker_environment/lib/test_environment/spawn_test_database.py#L294)
 -  [x]  [test_analyze_image/Dockerfile](https://github.com/exasol/integration-test-docker-environment/blob/main/exasol_integration_test_docker_environment/test/resources/test_docker_build_base/test_analyze_image/Dockerfile)
 - [x]  [test_test_container_reuse/tests/Dockerfile](https://github.com/exasol/integration-test-docker-environment/blob/main/exasol_integration_test_docker_environment/test/resources/test_test_container_reuse/tests/Dockerfile)
 - [x]  [test_api_test_environment_docker_environment.py](https://github.com/exasol/integration-test-docker-environment/blob/a77a910447a9b3571f8effb0b8cfd9cf6677b81e/exasol_integration_test_docker_environment/test/test_api_test_environment_docker_runtime.py#L22)
- [x]  Update Docker image for start scripts and test test containers from Ubuntu 20.04 (**EOL Apr 2025**) to Ubuntu 22.04
- https://github.com/search?q=repo%3Aexasol%2Fintegration-test-docker-environment%20ubuntu&type=code
- [x]  github workflows ubuntu version should be pinned 